### PR TITLE
#2: Add custom handler for ricemedia.co

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -1,6 +1,7 @@
 import tldextract
 
 from handlers.ArticleHandler import ArticleHandler
+from handlers.RicemediaHandler import RicemediaHandler
 
 
 class HandlerManager:
@@ -10,6 +11,7 @@ class HandlerManager:
     handlers = {
         "channelnewsasia.com": ArticleHandler,
         "mothership.sg": ArticleHandler,
+        "ricemedia.co": RicemediaHandler,
         "straitstimes.com": ArticleHandler,
         "todayonline.com": ArticleHandler,
         "zula.sg": ArticleHandler

--- a/handlers/RicemediaHandler/__init__.py
+++ b/handlers/RicemediaHandler/__init__.py
@@ -1,0 +1,30 @@
+from comment import Comment
+from handlers.AbstractBaseHandler import AbstractBaseHandler, HandlerError
+
+import requests
+import re
+from bs4 import BeautifulSoup
+import textwrap
+
+class RicemediaHandler(AbstractBaseHandler):
+    @classmethod
+    def handle(cls, url):
+      html = requests.get(url).text
+      soup = BeautifulSoup(html, 'html.parser')
+
+      #https://stackoverflow.com/a/24618186
+      # we only want article text, not inline scripts or inline jss
+      for script in soup(["script", "style"]):
+          script.extract()
+
+      #Plant markers to denote the start and end of the article
+      start_marker='EXTRACT_START'
+      end_marker='EXTRACT_END'
+      soup.find(name='div', class_='post-date').insert(0, start_marker)
+      soup.find(name='span', class_='author-name').append(end_marker)
+
+      unwrapped_body = re.search(f'{start_marker}(.+?){end_marker}', soup.text).group(1)
+      article_body = '\n'.join(textwrap.wrap(unwrapped_body,80))
+      article_title = soup.find(name='h2', class_='post-title').text
+
+      return Comment(article_title, article_body.replace('\xa0', ' '))


### PR DESCRIPTION
We make use of the fact that Rice articles start with the `post-date` and end with the `author-name`

Test: https://www.reddit.com/r/rsgretrivr/comments/aax6gi/the_stamford_raffles_statue_has_disappeared_and/ed0okgw
