### PR TITLE
Prevent program from crashing when exception occurs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 
 import praw
 import schedule
@@ -18,7 +19,12 @@ def start():
         username=config.USERNAME,
         password=config.PASSWORD)
 
-    scan(reddit.subreddit(config.SUBREDDIT))
+    try:
+        scan(reddit.subreddit(config.SUBREDDIT))
+    except Exception as e:
+        print("Exception occurred while scanning")
+        traceback.print_exc()
+
 
     DatabaseManager.disconnect()
 

--- a/scan.py
+++ b/scan.py
@@ -1,3 +1,5 @@
+import traceback
+
 import config
 from database import DatabaseManager, DatabaseActionEnum
 from handler import HandlerManager
@@ -18,7 +20,14 @@ def scan(subreddit):
             print("Submission qualifies")
 
             handler = HandlerManager.get_handler(submission.url)
-            comment_raw = handler.handle(submission.url)
+
+            comment_raw = None
+            try:
+                comment_raw = handler.handle(submission.url)
+            except Exception as e:
+                print(f"Exception occurred while handling {submission.url}")
+                traceback.print_exc()
+
             if comment_raw is None:
                 skip(submission)
                 return


### PR DESCRIPTION
This is an attempt to fix #13.

When a handler fails, the comment is skipped instead of an outright crash.
When scan fails, the current scan is aborted instead of an outright crash.

For example, when encountering something like #19, the new behaviour will be:

```
Operating on submission ID: avrr7y
Submission qualifies
Exception occurred while handling http://ricemedia.co/culture-life-chinese-dont-embrace-chinese-names/?fbclid=IwAR18XtmXgX5dDwCFbztRZ-yXx6r_2ycCHdWNYdTODd5KOyCv1ev8zZcUH20
Traceback (most recent call last):
  File "/code/scan.py", line 26, in scan
    comment_raw = handler.handle(submission.url)
  File "/code/handlers/RicemediaHandler/__init__.py", line 28, in handle
    unwrapped_body = re.search(f"{start_marker}(.+?){end_marker}", soup.text).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
Submission does not qualify
Checking if submission is new
Attempting to write skip to database
Starting write_id
Database write succeeded
Sleeping
```