### PR TITLE
Refactor configuration- and comment-related logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PRs are always welcome.
 
 ### New version release checklist
 1. Create a release branch (e.g. `release-v1.2.3`) from the `develop` branch
-2. Bump version numbers in `config.py` to the release branch
+2. Bump version numbers in `about.yaml` in the release branch
 3. Update README
 4. Possibly commit minor bug fixes to the release branch
 5. Merge the release branch into `master` and `develop` 

--- a/about.yaml
+++ b/about.yaml
@@ -1,0 +1,2 @@
+version: 1.0.2
+repo: https://github.com/fterh/sneakpeek

--- a/comment.py
+++ b/comment.py
@@ -1,32 +1,34 @@
-import config
+from config import bot_config
 
 
 class Comment:
-    def __init__(self, title, body, byline="", attribution=""):
+    def __init__(self, title: str, body: str, byline: str = "", attribution: str = ""):
         self.title = title
         self.body = body
         self.byline = byline
         self.attribution = attribution
 
+    def length(self) -> int:
+        return sum(
+            map(len, [self.title, self.body, self.byline, self.attribution])
+        )
 
-def generate_title_markdown(title):
-    return "> # " + title
+    def _title_as_md(self) -> str:
+        return "> # " + self.title
 
+    def _body_as_md(self) -> str:
+        body_md = "> " + self.body  # Insert first blockquote (>) Markdown symbol
+        return body_md.replace("\n\n", "\n\n> ")
 
-def generate_body_markdown(body):
-    body = "> " + body # Insert first blockquote (>) Markdown symbol
-    body = body.replace("\n\n", "\n\n> ")
-    return body
+    @staticmethod
+    def footer() -> str:
+        return f"---\n{bot_config.version} | [Source code]({bot_config.repo}) | [Contribute]({bot_config.repo})"
 
-
-COMMENT_FOOTER = "---\n{} | [Source code]({}) | [Contribute]({})".format(
-    config.BOT["VERSION"],
-    config.BOT["REPO_LINK"],
-    config.BOT["CONTRIBUTE_LINK"]
-)
-
-
-def format_comment(comment):
-    return generate_title_markdown(comment.title) + \
-        "\n\n" + generate_body_markdown(comment.body) + \
-        "\n\n" + COMMENT_FOOTER
+    def format_as_md(self) -> str:
+        return '\n\n'.join(
+            [
+                self._title_as_md(),
+                self._body_as_md(),
+                self.footer()
+            ]
+        )

--- a/config.py
+++ b/config.py
@@ -5,24 +5,19 @@ import yaml
 from dotenv import load_dotenv
 
 
-load_dotenv()
-
-# Logging configuration
-LOGGING = {
-    "LEVEL": logging.DEBUG,
-    "HANDLER": logging.StreamHandler(sys.stdout)  # Log to stdout (see: https://12factor.net/logs)
-}
-
-
 class BotConfig:
     def __init__(self):
         load_dotenv()
+
         self.client_id: str = os.getenv('CLIENT_ID')
         self.client_secret: str = os.getenv('CLIENT_SECRET')
         self.username: str = os.getenv('USERNAME')
         self.password: str = os.getenv('PASSWORD')
         self.user_agent: str = os.getenv('USER_AGENT')
         self.comment_length_limit: int = 9900
+
+        self.logging_level = logging.DEBUG
+        self.logging_handler = logging.StreamHandler(sys.stdout)
 
         # Read subreddit from environment variable; warn and default to /r/all if not set
         self.subreddit: str = os.getenv('SUBREDDIT')

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import yaml
 from dotenv import load_dotenv
 
 
@@ -12,26 +13,32 @@ LOGGING = {
     "HANDLER": logging.StreamHandler(sys.stdout)  # Log to stdout (see: https://12factor.net/logs)
 }
 
-BOT = {
-    "VERSION": "1.0.2",
-    "REPO_LINK": "https://github.com/fterh/sneakpeek",
-    "CONTRIBUTE_LINK": "https://github.com/fterh/sneakpeek"
-}
 
-CLIENT = {
-    "ID": os.getenv("CLIENT_ID"),
-    "SECRET": os.getenv("CLIENT_SECRET")
-}
+class BotConfig:
+    def __init__(self):
+        load_dotenv()
+        self.client_id: str = os.getenv('CLIENT_ID')
+        self.client_secret: str = os.getenv('CLIENT_SECRET')
+        self.username: str = os.getenv('USERNAME')
+        self.password: str = os.getenv('PASSWORD')
+        self.user_agent: str = os.getenv('USER_AGENT')
+        self.comment_length_limit: int = 9900
 
-USERNAME = os.getenv("USERNAME")
-PASSWORD = os.getenv("PASSWORD")
+        # Read subreddit from environment variable; warn and default to /r/all if not set
+        self.subreddit: str = os.getenv('SUBREDDIT')
+        if self.subreddit is None:
+            logging.warning('Environment variable `SUBREDDIT` is not set; defaulting to `all`')
+            self.subreddit: str = 'all'
 
-USER_AGENT = os.getenv("USER_AGENT")
+        # load details about bot
+        with open('about.yaml', 'r') as f:
+            about = yaml.safe_load(f)
+        if about is None:
+            logging.error('Couldn\'t load \'about.yaml\'')
+        self.version = about.get('version')
+        self.repo = about.get('repo')
 
-# Read subreddit from environment variable; warn and default to /r/all if not set
-SUBREDDIT = os.getenv("SUBREDDIT")
-if SUBREDDIT is None:
-    logging.warning("Environment variable `SUBREDDIT` is not set; defaulting to `all`")
-    SUBREDDIT = "all"
 
-COMMENT_LENGTH_LIMIT = 9900
+# This is a shitty singleton, but it gets the job done!
+# Always import bot_config instead of BotConfig
+bot_config = BotConfig()

--- a/handlers/abstract_base_handler.py
+++ b/handlers/abstract_base_handler.py
@@ -1,6 +1,7 @@
 """The abstract base Handler class which all Handlers must subclass."""
 
 from abc import ABC, abstractmethod
+from comment import Comment
 
 
 class AbstractBaseHandler(ABC):
@@ -8,7 +9,7 @@ class AbstractBaseHandler(ABC):
 
     @classmethod
     @abstractmethod
-    def handle(cls, url):
+    def handle(cls, url) -> Comment:
         """
         All Handlers must override the `handle` method,
         which must return a Comment object.

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 
 import logging
 import praw
-import config
 from scan import scan
 from config import bot_config
 
@@ -10,10 +9,10 @@ from config import bot_config
 def setup_logging():
     """Configure project logging options."""
     root = logging.getLogger()
-    root.setLevel(config.LOGGING["LEVEL"])
+    root.setLevel(bot_config.logging_level)
 
-    handler = config.LOGGING["HANDLER"]
-    handler.setLevel(logging.DEBUG)
+    handler = bot_config.logging_handler
+    handler.setLevel(bot_config.logging_level)
 
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import logging
 import praw
 import config
 from scan import scan
+from config import bot_config
 
 
 def setup_logging():
@@ -24,15 +25,17 @@ def start():
     """Start the sneakpeek application."""
     logging.info("Starting application")
     logging.info("Instantiating Reddit instance")
+
     reddit = praw.Reddit(
-        client_id=config.CLIENT["ID"],
-        client_secret=config.CLIENT["SECRET"],
-        user_agent=config.USER_AGENT,
-        username=config.USERNAME,
-        password=config.PASSWORD)
+        client_id=bot_config.client_id,
+        client_secret=bot_config.client_secret,
+        user_agent=bot_config.user_agent,
+        username=bot_config.username,
+        password=bot_config.password
+    )
 
     try:
-        scan(reddit.subreddit(config.SUBREDDIT))
+        scan(reddit.subreddit(bot_config.subreddit))
     except Exception as exception:
         # This should never happen,
         # because it breaks the infinite subreddit monitoring

--- a/scan.py
+++ b/scan.py
@@ -3,8 +3,8 @@
 import logging
 import config
 from handler import HandlerManager
-from comment import format_comment
 from qualify import qualify
+from config import bot_config
 
 
 def scan(subreddit):
@@ -39,10 +39,10 @@ def scan(subreddit):
             logging.info("Skipping current submission")
             continue
 
-        comment_raw = None
+        comment = None
         try:
             logging.info("Attempting to generate raw comment using handler")
-            comment_raw = handler.handle(submission.url)
+            comment = handler.handle(submission.url)
             logging.info("Raw comment generated")
         except Exception as exception:
             logging.error("An error occurred while handling URL = %s",
@@ -51,15 +51,15 @@ def scan(subreddit):
             logging.info("Skipping current submission")
             continue
 
-        if comment_raw is None:
+        if comment is None:
             logging.error("comment_raw is None; skipping current submission")
             continue
 
         logging.info("Generating formatted comment")
-        comment_markdown = format_comment(comment_raw)
+        comment_markdown = comment.format_as_md()
         logging.info("Formatted comment generated")
 
-        if len(comment_markdown) < 2*config.COMMENT_LENGTH_LIMIT:
+        if len(comment_markdown) < 2 * bot_config.comment_length_limit:
             try:
                 logging.info("Attempting to post comment")
                 submission.reply(comment_markdown)
@@ -70,10 +70,10 @@ def scan(subreddit):
                 try:
                     logging.info("Attempting to post two comments")
                     i=1
-                    while (comment_markdown[config.COMMENT_LENGTH_LIMIT-i] != " "):
+                    while (comment_markdown[bot_config.comment_length_limit - i] != " "):
                         i += 1
-                    part_1 = comment_markdown[0: config.COMMENT_LENGTH_LIMIT-i]
-                    part_2 = comment_markdown[config.COMMENT_LENGTH_LIMIT-i:]
+                    part_1 = comment_markdown[0:bot_config.comment_length_limit-i]
+                    part_2 = comment_markdown[bot_config.comment_length_limit-i:]
 
                     if (part_2[0] != ">"):
                         part_2 = ">" + part_2

--- a/scan.py
+++ b/scan.py
@@ -1,7 +1,6 @@
 """Monitor a Subreddit for new submissions."""
 
 import logging
-import config
 from handler import HandlerManager
 from qualify import qualify
 from config import bot_config

--- a/test_scan.py
+++ b/test_scan.py
@@ -5,14 +5,16 @@ import unittest
 from unittest import mock, TestCase
 
 import config
+from comment import Comment
 
 # Set ENV to "test" before loading scan module
 config.ENV = "test"
 
 from scan import scan
+from config import bot_config
 import test_qualify
 
-RAW_COMMENT = "some_raw_comment_text"
+RAW_COMMENT = Comment(title='This is a thing', body='some_raw_comment_text')
 FORMATTED_COMMENT = "some_formatted_comment_text"
 
 # Set up mock objects
@@ -31,9 +33,9 @@ class TestScan(TestCase):
 
     @mock.patch("scan.qualify")
     @mock.patch("scan.HandlerManager")
-    @mock.patch("scan.format_comment")
+    @mock.patch("comment.Comment.format_as_md")
     def test_success(self,
-                     mock_format_comment,
+                     mock_comment_format,
                      mock_HandlerManager,
                      mock_qualify
                      ):
@@ -42,7 +44,7 @@ class TestScan(TestCase):
         """
         mock_qualify.return_value = True
         mock_HandlerManager.get_handler.return_value = MOCK_HANDLER
-        mock_format_comment.return_value = FORMATTED_COMMENT
+        mock_comment_format.return_value = FORMATTED_COMMENT
 
         scan(MOCK_SUBREDDIT)
 
@@ -63,9 +65,9 @@ class TestScan(TestCase):
 
     @mock.patch("scan.qualify")
     @mock.patch("scan.HandlerManager")
-    @mock.patch("scan.format_comment")
+    @mock.patch("comment.Comment.format_as_md")
     def test_skip_2(self,
-                    mock_format_comment,
+                    mock_comment_format,
                     mock_HandlerManager,
                     mock_qualify
                     ):
@@ -74,13 +76,14 @@ class TestScan(TestCase):
         """
         mock_qualify.return_value = True
         mock_HandlerManager.get_handler.return_value = MOCK_HANDLER
-        mock_format_comment.return_value = FORMATTED_COMMENT
-        original_comment_length_limit = config.COMMENT_LENGTH_LIMIT
-        config.COMMENT_LENGTH_LIMIT = 1
+        mock_comment_format.return_value = FORMATTED_COMMENT
+        original_comment_length_limit = bot_config.comment_length_limit
+
+        bot_config.comment_length_limit = 1
 
         scan(MOCK_SUBREDDIT)
 
-        config.COMMENT_LENGTH_LIMIT = original_comment_length_limit
+        bot_config.comment_length_limit = original_comment_length_limit
 
         test_qualify.MOCK_SUBMISSION.reply.assert_not_called()
 


### PR DESCRIPTION
I migrated `comment.py` to a more object-oriented approach. This doesn't add any new features, but it makes it easier to maintain and make changes to the bot. This also grants developers the lovely support of autocomplete and type hints for easier development.

This paves the way for migrating the split-long-comment-into-two-comments logic below into a nicer abstraction so that concerns are properly separated and you don't have to limit the bot to exactly two comments.

https://github.com/fterh/sneakpeek/blob/5e25bae6ec14c714c964b7558795d4cdc91ba714/scan.py#L70-L83

I also modified some parts of `config.py`. The version and repo link is now put inside `about.yaml` so that no source code changes are required to bump the version - this makes the git history cleaner for code. It also removes the magic strings from other classes/files.

Since I did this, I decided to also create a unified interface to access all bot configuration parameters, the `BotConfig`, which you can inject wherever needed.